### PR TITLE
Handle local date correctly and add Express server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ npm start
 
 L'application sera disponible à l'adresse [http://localhost:3000](http://localhost:3000).
 
+### Démarrer le serveur backend
+
+```bash
+cd server
+npm install
+npm start
+```
+
+Le serveur répond par défaut sur [http://localhost:3001](http://localhost:3001).
+
 ## 📱 Captures d'écran
 
 <div align="center">
@@ -58,6 +68,7 @@ L'application sera disponible à l'adresse [http://localhost:3000](http://localh
 ```
 carnet-maintenance-pac/
 ├── public/                # Fichiers accessibles publiquement
+├── server/                # Serveur Express pour l'API
 ├── src/                   # Code source de l'application
 │   ├── components/        # Composants React réutilisables
 │   ├── data/              # Données et structures de données

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,19 @@
+# Server
+
+This directory contains a simple Express server for the project.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Start the server (defaults to port 3001):
+   ```bash
+   npm start
+   ```
+
+3. Visit [http://localhost:3001](http://localhost:3001) to verify the server is running.
+
+You can change the port by setting the `PORT` environment variable before starting the server.

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,12 @@
+const express = require('express');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.get('/', (req, res) => {
+  res.send('Server is running');
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "scripts": {
+    "start": "node index.js"
+  }
+}

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -54,5 +54,9 @@ export const getTodayFrenchFormat = () => {
  * @returns {string} - Date actuelle au format ISO
  */
 export const getTodayISOFormat = () => {
-  return new Date().toISOString().split('T')[0];
+  const today = new Date();
+  const day = String(today.getDate()).padStart(2, '0');
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const year = today.getFullYear();
+  return `${year}-${month}-${day}`;
 };

--- a/src/utils/dateUtils.test.js
+++ b/src/utils/dateUtils.test.js
@@ -1,0 +1,27 @@
+import { getTodayISOFormat } from './dateUtils';
+
+describe('getTodayISOFormat', () => {
+  const RealDate = Date;
+  beforeAll(() => {
+    class MockDate extends RealDate {
+      constructor(...args) {
+        if (args.length) {
+          super(...args);
+          return;
+        }
+        super('2023-01-01T00:30:00Z');
+      }
+      getFullYear() { return 2022; }
+      getMonth() { return 11; } // December (0-indexed)
+      getDate() { return 31; }
+    }
+    global.Date = MockDate;
+  });
+  afterAll(() => {
+    global.Date = RealDate;
+  });
+
+  it('returns the local date in ISO format', () => {
+    expect(getTodayISOFormat()).toBe('2022-12-31');
+  });
+});


### PR DESCRIPTION
## Summary
- handle local timezone correctly in `getTodayISOFormat`
- add unit test for date utility
- add Express-based backend server with documentation

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689065e24bb4832289a97ef5b4bde79c