### PR TITLE
Handle local date correctly and add machine API server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+server/database.sqlite

--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ npm start
 
 L'application sera disponible à l'adresse [http://localhost:3000](http://localhost:3000).
 
+### Démarrer le serveur backend
+
+```bash
+cd server
+npm install
+npm start
+```
+
+Le serveur répond par défaut sur [http://localhost:3001](http://localhost:3001).
+Il initialise une base SQLite avec les données de `server/data/machines.json`.
+
+#### API disponible
+
+- `GET /api/machines` – liste toutes les machines avec leur historique d'interventions
+- `GET /api/machines/:id` – détail d'une machine par identifiant
+
 ## 📱 Captures d'écran
 
 <div align="center">
@@ -58,6 +74,7 @@ L'application sera disponible à l'adresse [http://localhost:3000](http://localh
 ```
 carnet-maintenance-pac/
 ├── public/                # Fichiers accessibles publiquement
+├── server/                # Serveur Express pour l'API
 ├── src/                   # Code source de l'application
 │   ├── components/        # Composants React réutilisables
 │   ├── data/              # Données et structures de données

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,26 @@
+# Server
+
+This directory contains an Express server for the project.
+
+## Setup
+
+1. Install dependencies and initialize the SQLite database:
+   ```bash
+   npm install
+   ```
+
+2. Start the server (defaults to port 3001):
+   ```bash
+   npm start
+   ```
+
+The server reads machine data from `data/machines.json` on first start and persists it to `database.sqlite`.
+
+### API
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET    | `/api/machines` | List all machines with their intervention history |
+| GET    | `/api/machines/:id` | Retrieve a single machine by ID |
+
+You can change the port by setting the `PORT` environment variable before starting the server.

--- a/server/data/machines.json
+++ b/server/data/machines.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "PAC001",
+    "serialNumber": "SN-PAC001",
+    "name": "Pompe à chaleur A",
+    "description": "Machine située dans la salle technique A",
+    "history": [
+      { "date": "2024-01-10", "description": "Installation" },
+      { "date": "2024-06-15", "description": "Maintenance annuelle" }
+    ]
+  },
+  {
+    "id": "PAC002",
+    "serialNumber": "SN-PAC002",
+    "name": "Pompe à chaleur B",
+    "description": "Machine située dans la salle technique B",
+    "history": [
+      { "date": "2024-02-20", "description": "Installation" },
+      { "date": "2024-08-05", "description": "Révision trimestrielle" }
+    ]
+  }
+]

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
+
+const dbPath = path.join(__dirname, 'database.sqlite');
+const db = new Database(dbPath);
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS machines (
+    id TEXT PRIMARY KEY,
+    serial_number TEXT,
+    name TEXT,
+    description TEXT
+  );
+  CREATE TABLE IF NOT EXISTS interventions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    machine_id TEXT,
+    date TEXT,
+    description TEXT,
+    FOREIGN KEY(machine_id) REFERENCES machines(id) ON DELETE CASCADE
+  );
+`);
+
+const machineCount = db.prepare('SELECT COUNT(*) as count FROM machines').get().count;
+if (machineCount === 0) {
+  const dataFile = path.join(__dirname, 'data', 'machines.json');
+  const machines = JSON.parse(fs.readFileSync(dataFile, 'utf-8'));
+
+  const insertMachine = db.prepare('INSERT INTO machines (id, serial_number, name, description) VALUES (?, ?, ?, ?)');
+  const insertIntervention = db.prepare('INSERT INTO interventions (machine_id, date, description) VALUES (?, ?, ?)');
+
+  const seed = db.transaction(() => {
+    machines.forEach(m => {
+      insertMachine.run(m.id, m.serialNumber, m.name, m.description);
+      if (Array.isArray(m.history)) {
+        m.history.forEach(h => {
+          insertIntervention.run(m.id, h.date, h.description);
+        });
+      }
+    });
+  });
+
+  seed();
+}
+
+module.exports = db;

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const db = require('./db');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(express.json());
+
+app.get('/api/machines', (req, res) => {
+  const machines = db.prepare('SELECT * FROM machines').all();
+  const interventions = db.prepare('SELECT machine_id, date, description FROM interventions').all();
+  const historyMap = {};
+  interventions.forEach(i => {
+    if (!historyMap[i.machine_id]) historyMap[i.machine_id] = [];
+    historyMap[i.machine_id].push({ date: i.date, description: i.description });
+  });
+  const result = machines.map(m => ({
+    id: m.id,
+    serialNumber: m.serial_number,
+    name: m.name,
+    description: m.description,
+    history: historyMap[m.id] || []
+  }));
+  res.json(result);
+});
+
+app.get('/api/machines/:id', (req, res) => {
+  const machine = db.prepare('SELECT * FROM machines WHERE id = ?').get(req.params.id);
+  if (!machine) {
+    return res.status(404).json({ error: 'Machine not found' });
+  }
+  const history = db.prepare('SELECT date, description FROM interventions WHERE machine_id = ?').all(req.params.id);
+  res.json({
+    id: machine.id,
+    serialNumber: machine.serial_number,
+    name: machine.name,
+    description: machine.description,
+    history
+  });
+});
+
+app.get('/', (req, res) => {
+  res.send('Server is running');
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "express": "^4.18.2",
+    "better-sqlite3": "^9.4.1"
+  },
+  "scripts": {
+    "start": "node index.js"
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import CarnetMaintenancePAC from './components/CarnetMaintenancePAC';
+import MachineCatalog from './components/MachineCatalog';
 
 function App() {
   return (
     <div className="App">
       <CarnetMaintenancePAC />
+      <MachineCatalog />
     </div>
   );
 }

--- a/src/components/MachineCatalog.js
+++ b/src/components/MachineCatalog.js
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import { fetchMachines } from '../services/MachineApi';
+
+/**
+ * Affiche la liste des machines récupérées depuis l'API backend
+ */
+const MachineCatalog = () => {
+  const [machines, setMachines] = useState([]);
+
+  useEffect(() => {
+    fetchMachines()
+      .then(setMachines)
+      .catch(err => console.error('Erreur de chargement des machines', err));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h2 className="text-lg font-semibold mb-2">Catalogue des machines</h2>
+      <ul className="space-y-2">
+        {machines.map(machine => (
+          <li key={machine.id} className="border p-2 rounded">
+            <p className="font-medium">{machine.name} ({machine.serialNumber})</p>
+            <p className="text-sm text-gray-600 mb-1">{machine.description}</p>
+            {machine.history.length > 0 && (
+              <ul className="ml-4 list-disc text-sm text-gray-700">
+                {machine.history.map((h, idx) => (
+                  <li key={idx}>{h.date} - {h.description}</li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MachineCatalog;

--- a/src/services/MachineApi.js
+++ b/src/services/MachineApi.js
@@ -1,0 +1,20 @@
+/**
+ * Client API pour récupérer les machines depuis le serveur
+ */
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+
+export async function fetchMachines() {
+  const res = await fetch(`${API_BASE_URL}/api/machines`);
+  if (!res.ok) {
+    throw new Error('Impossible de récupérer les machines');
+  }
+  return res.json();
+}
+
+export async function fetchMachine(id) {
+  const res = await fetch(`${API_BASE_URL}/api/machines/${id}`);
+  if (!res.ok) {
+    throw new Error('Impossible de récupérer la machine');
+  }
+  return res.json();
+}

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -54,5 +54,9 @@ export const getTodayFrenchFormat = () => {
  * @returns {string} - Date actuelle au format ISO
  */
 export const getTodayISOFormat = () => {
-  return new Date().toISOString().split('T')[0];
+  const today = new Date();
+  const day = String(today.getDate()).padStart(2, '0');
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const year = today.getFullYear();
+  return `${year}-${month}-${day}`;
 };

--- a/src/utils/dateUtils.test.js
+++ b/src/utils/dateUtils.test.js
@@ -1,0 +1,27 @@
+import { getTodayISOFormat } from './dateUtils';
+
+describe('getTodayISOFormat', () => {
+  const RealDate = Date;
+  beforeAll(() => {
+    class MockDate extends RealDate {
+      constructor(...args) {
+        if (args.length) {
+          super(...args);
+          return;
+        }
+        super('2023-01-01T00:30:00Z');
+      }
+      getFullYear() { return 2022; }
+      getMonth() { return 11; } // December (0-indexed)
+      getDate() { return 31; }
+    }
+    global.Date = MockDate;
+  });
+  afterAll(() => {
+    global.Date = RealDate;
+  });
+
+  it('returns the local date in ISO format', () => {
+    expect(getTodayISOFormat()).toBe('2022-12-31');
+  });
+});


### PR DESCRIPTION
## Summary
- handle local timezone correctly in `getTodayISOFormat`
- add unit test for date utility
- add Express-based backend server with documentation
- expose machine inventory from SQLite database through `/api/machines`
- provide React API client and catalog component to display machine data

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689065e24bb4832289a97ef5b4bde79c